### PR TITLE
strip additional comments from /etc/default/passwd

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -347,6 +347,7 @@ import pwd
 import shutil
 import socket
 import time
+import re
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import load_platform_subclass, AnsibleModule
@@ -1490,6 +1491,9 @@ class SunOS(User):
                 line = line.strip()
                 if (line.startswith('#') or line == ''):
                     continue
+                m = re.match(r'^([^#]*)#(.*)$', line)
+                if m:  # The line contains a hash / comment
+                line = m.group(1)
                 key, value = line.split('=')
                 if key == "MINWEEKS":
                     minweeks = value.rstrip('\n')
@@ -2483,6 +2487,7 @@ def main():
     module.exit_json(**result)
 
 
-# import module snippets
+# 
+module snippets
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2487,6 +2487,6 @@ def main():
     module.exit_json(**result)
 
 
-# module snippets
+# import module snippets
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2487,7 +2487,6 @@ def main():
     module.exit_json(**result)
 
 
-# 
-module snippets
+# module snippets
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
Strip trailling comments from /etc/default/passwd like:
MINWEEKS=1 #MINWEEKS=2
MAXWEEKS=12  # MAXWEEKS=8
Which otherwise cause failures with "failed to read /etc/default/passwd: too many values to unpack"

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
user module

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /development/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May 31 2018, 09:41:32) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]
```
But present in the current 2.6+ releases too.

##### ADDITIONAL INFORMATION

Example input file
```
#ident  "@(#)passwd.dfl 1.8     14/01/24 SMI"
#
# Copyright (c) 1989, 2014, Oracle and/or its affiliates. All rights reserved.
#
MAXWEEKS=12 #MAXWEEKS=8
MINWEEKS=0  # MINWEEKS=4
PASSLENGTH=8
MINALPHA=1 # MINALPHA = 2
#WHITESPACE=YES
#
```

Old code fails with `ValueError: too many values to unpack`
```
import sys

def get_password_defaults():
    # Read password aging defaults
    minweeks = ''
    maxweeks = ''
    warnweeks = ''
    for line in open("/tmp/default_passwd", 'r'):
        line = line.strip()
        if (line.startswith('#') or line == ''):
            continue
        key, value = line.split('=')

        if key == "MINWEEKS":
            minweeks = value.rstrip('\n')
        elif key == "MAXWEEKS":
            maxweeks = value.rstrip('\n')
        elif key == "WARNWEEKS":
            warnweeks = value.rstrip('\n')

    return (minweeks, maxweeks, warnweeks)

minweeks, maxweeks, warnweeks = get_password_defaults()
```

Fixed code strips trailing comments
```
import sys
import re

def get_password_defaults():
    # Read password aging defaults
    minweeks = ''
    maxweeks = ''
    warnweeks = ''
    for line in open("/tmp/default_passwd", 'r'):
        line = line.strip()
        if (line.startswith('#') or line == ''):
            continue
        m = re.match(r'^([^#]*)#(.*)$', line)
        if m:  # The line contains a hash / comment
            line = m.group(1)
        key, value = line.split('=')

        if key == "MINWEEKS":
            minweeks = value.rstrip('\n')
        elif key == "MAXWEEKS":
            maxweeks = value.rstrip('\n')
        elif key == "WARNWEEKS":
            warnweeks = value.rstrip('\n')

    return (minweeks, maxweeks, warnweeks)

minweeks, maxweeks, warnweeks = get_password_defaults()
```
